### PR TITLE
Initialize Vue frontend and ASP.NET backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# proyectoIaClaudio
+# Proyecto IA Claudio
+
+Este repositorio contiene una estructura base compuesta por:
+
+- **frontend/**: aplicación Vue 3 con TypeScript configurada con Tailwind CSS, Vue Router, Pinia, Vitest y
+  Playwright.
+- **backend/**: API minimal construida con ASP.NET Core 8 en C# con endpoints CRUD en memoria.
+- **scripts/**: carpeta preparada para almacenar scripts de base de datos MSSQL.
+
+Consulta los archivos README dentro de cada carpeta para obtener instrucciones específicas de ejecución y
+desarrollo.

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,9 @@
+bin/
+obj/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+appsettings.Development.json
+appsettings.Local.json
+.vs/

--- a/backend/BackendApi.csproj
+++ b/backend/BackendApi.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,0 +1,90 @@
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddDbContext<TodoDbContext>(options =>
+    options.UseInMemoryDatabase("Todos"));
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapGet("/", () => Results.Json(new { message = "API minimal ASP.NET Core lista" }))
+   .WithName("GetRoot")
+   .WithOpenApi();
+
+app.MapGet("/todos", async (TodoDbContext db) =>
+        await db.Todos.ToListAsync())
+   .WithName("GetTodos")
+   .WithOpenApi();
+
+app.MapPost("/todos", async (TodoDbContext db, TodoItem todo) =>
+    {
+        db.Todos.Add(todo);
+        await db.SaveChangesAsync();
+        return Results.Created($"/todos/{todo.Id}", todo);
+    })
+   .WithName("CreateTodo")
+   .WithOpenApi();
+
+app.MapPut("/todos/{id}", async (TodoDbContext db, int id, TodoItem input) =>
+    {
+        var todo = await db.Todos.FindAsync(id);
+        if (todo is null)
+        {
+            return Results.NotFound();
+        }
+
+        todo.Title = input.Title;
+        todo.IsComplete = input.IsComplete;
+        await db.SaveChangesAsync();
+
+        return Results.NoContent();
+    })
+   .WithName("UpdateTodo")
+   .WithOpenApi();
+
+app.MapDelete("/todos/{id}", async (TodoDbContext db, int id) =>
+    {
+        var todo = await db.Todos.FindAsync(id);
+        if (todo is null)
+        {
+            return Results.NotFound();
+        }
+
+        db.Todos.Remove(todo);
+        await db.SaveChangesAsync();
+
+        return Results.NoContent();
+    })
+   .WithName("DeleteTodo")
+   .WithOpenApi();
+
+app.Run();
+
+class TodoDbContext : DbContext
+{
+    public TodoDbContext(DbContextOptions<TodoDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<TodoItem> Todos => Set<TodoItem>();
+}
+
+class TodoItem
+{
+    public int Id { get; set; }
+
+    public string Title { get; set; } = string.Empty;
+
+    public bool IsComplete { get; set; }
+}

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,15 @@
+# Backend
+
+API minimal construida con [ASP.NET Core](https://learn.microsoft.com/aspnet/core/?view=aspnetcore-8.0) en
+C#.
+
+## Ejecución
+
+```bash
+cd backend
+ dotnet restore
+ dotnet run
+```
+
+La API expone endpoints básicos para gestionar tareas en memoria y cuenta con documentación generada
+por Swagger en `/swagger` cuando se ejecuta en modo desarrollo.

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.DS_Store
+dist
+*.local
+coverage
+.vscode
+.idea

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,20 @@
+# Frontend
+
+Aplicación creada con [Vue 3](https://vuejs.org/), [TypeScript](https://www.typescriptlang.org/) y
+[Tailwind CSS](https://tailwindcss.com/) usando Vite como bundler.
+
+## Scripts disponibles
+
+- `npm install` instala las dependencias.
+- `npm run dev` inicia el servidor de desarrollo.
+- `npm run build` genera la compilación de producción.
+- `npm run preview` sirve la compilación generada.
+- `npm run test:unit` ejecuta las pruebas unitarias con Vitest.
+- `npm run test:e2e` ejecuta las pruebas E2E con Playwright.
+- `npm run lint` ejecuta ESLint.
+- `npm run format` formatea el código con Prettier.
+
+## Tailwind CSS
+
+El framework utilitario Tailwind CSS está configurado con `tailwind.config.cjs` y se incluye en el
+archivo `src/assets/main.css`.

--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,24 @@
+import js from '@eslint/js';
+import pluginVue from 'eslint-plugin-vue';
+import prettier from 'eslint-config-prettier';
+import ts from 'typescript-eslint';
+
+export default ts.config(
+  js.configs.recommended,
+  ...pluginVue.configs['flat/essential'],
+  ...ts.configs.recommended,
+  prettier,
+  {
+    files: ['**/*.{ts,tsx,vue}'],
+    languageOptions: {
+      parserOptions: {
+        parser: ts.parser,
+        ecmaVersion: 'latest',
+        sourceType: 'module'
+      }
+    },
+    rules: {
+      'vue/multi-word-component-names': 'off'
+    }
+  }
+);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vue 3 + TypeScript + Tailwind</title>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "frontend",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc -b && vite build",
+    "preview": "vite preview",
+    "test:unit": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui",
+    "lint": "eslint .",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "pinia": "^2.1.7",
+    "vue": "^3.4.21",
+    "vue-router": "^4.3.2"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.43.1",
+    "@types/node": "^20.11.30",
+    "@vitejs/plugin-vue": "^5.0.4",
+    "@vue/eslint-config-prettier": "^10.0.0",
+    "@vue/eslint-config-typescript": "^12.0.0",
+    "@vue/test-utils": "^2.4.5",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-plugin-vue": "^9.23.0",
+    "postcss": "^8.4.38",
+    "prettier": "^3.2.5",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.9",
+    "vitest": "^1.5.3",
+    "vue-tsc": "^2.0.19"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <main class="min-h-screen bg-gradient-to-br from-slate-900 via-slate-950 to-black">
+    <section class="mx-auto flex max-w-3xl flex-col items-center gap-6 px-4 py-16 text-center">
+      <img alt="Vue logo" class="h-24 w-24" src="/vite.svg" />
+      <h1 class="text-4xl font-bold tracking-tight text-emerald-400 sm:text-5xl">
+        Bienvenido a tu nueva aplicación Vue 3 + TypeScript
+      </h1>
+      <p class="text-lg text-slate-300">
+        Este proyecto está listo para usarse con Tailwind CSS, Vue Router y Pinia. Empieza editando
+        <span class="font-mono text-emerald-300">src/components/HelloWorld.vue</span>.
+      </p>
+      <HelloWorld msg="¡Hola desde Vue!" />
+    </section>
+  </main>
+</template>
+
+<style scoped>
+main {
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+</style>

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}

--- a/frontend/src/components/HelloWorld.vue
+++ b/frontend/src/components/HelloWorld.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useCounterStore } from '@/stores/counter';
+
+defineProps<{
+  msg: string;
+}>();
+
+const counter = useCounterStore();
+const doubledCount = computed(() => counter.count * 2);
+const name = ref('Vue');
+</script>
+
+<template>
+  <div class="flex flex-col items-center gap-4 rounded-xl border border-slate-800 bg-slate-900/60 p-8 shadow-lg">
+    <h2 class="text-2xl font-semibold text-emerald-300">{{ msg }}</h2>
+    <p class="text-slate-300">
+      Contador global: <span class="font-bold text-emerald-400">{{ counter.count }}</span>
+      (doble: <span class="font-bold text-emerald-400">{{ doubledCount }}</span>)
+    </p>
+    <div class="flex flex-wrap items-center justify-center gap-3">
+      <button
+        class="rounded-lg bg-emerald-500 px-4 py-2 font-semibold text-slate-950 transition hover:bg-emerald-400"
+        type="button"
+        @click="counter.increment()"
+      >
+        Incrementar
+      </button>
+      <button
+        class="rounded-lg border border-emerald-500 px-4 py-2 font-semibold text-emerald-300 transition hover:bg-emerald-500/10"
+        type="button"
+        @click="counter.reset()"
+      >
+        Reiniciar
+      </button>
+    </div>
+    <label class="text-slate-300">
+      <span class="mr-2">¿Cómo te llamas?</span>
+      <input
+        v-model="name"
+        class="rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none"
+        placeholder="Introduce tu nombre"
+        type="text"
+      />
+    </label>
+    <p class="text-slate-400">Encantado de conocerte, {{ name || 'amigo' }} 👋</p>
+    <RouterLink
+      class="text-sm font-semibold uppercase tracking-wider text-emerald-400 hover:text-emerald-300"
+      to="/about"
+    >
+      Ir a la página de ejemplo
+    </RouterLink>
+  </div>
+</template>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,14 @@
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+
+import App from './App.vue';
+import router from './router';
+
+import './assets/main.css';
+
+const app = createApp(App);
+
+app.use(createPinia());
+app.use(router);
+
+app.mount('#app');

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,0 +1,19 @@
+import { createRouter, createWebHistory } from 'vue-router';
+
+const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: () => import('../components/HelloWorld.vue')
+    },
+    {
+      path: '/about',
+      name: 'about',
+      component: () => import('../views/AboutView.vue')
+    }
+  ]
+});
+
+export default router;

--- a/frontend/src/stores/counter.ts
+++ b/frontend/src/stores/counter.ts
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia';
+
+export const useCounterStore = defineStore('counter', {
+  state: () => ({
+    count: 0
+  }),
+  actions: {
+    increment() {
+      this.count += 1;
+    },
+    reset() {
+      this.count = 0;
+    }
+  }
+});

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="flex min-h-screen flex-col items-center justify-center gap-6 bg-slate-950 px-6 py-16 text-center text-slate-200">
+    <h2 class="text-3xl font-bold text-emerald-400">Página de ejemplo</h2>
+    <p class="max-w-xl text-base text-slate-300">
+      Esta es una ruta adicional configurada con Vue Router. Utiliza Tailwind CSS para definir estilos
+      utilitarios y demuestra cómo navegar entre páginas en una aplicación Vue 3.
+    </p>
+    <RouterLink
+      class="rounded-md bg-emerald-500 px-4 py-2 font-semibold text-slate-950 transition hover:bg-emerald-400"
+      to="/"
+    >
+      Volver al inicio
+    </RouterLink>
+  </div>
+</template>

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/frontend/tests/e2e/example.spec.ts
+++ b/frontend/tests/e2e/example.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('la aplicación carga la página principal', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('h1')).toContainText('Bienvenido a tu nueva aplicación Vue 3 + TypeScript');
+});

--- a/frontend/tests/unit/HelloWorld.spec.ts
+++ b/frontend/tests/unit/HelloWorld.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import HelloWorld from '@/components/HelloWorld.vue';
+
+describe('HelloWorld', () => {
+  it('muestra el mensaje recibido por props', () => {
+    const wrapper = mount(HelloWorld, {
+      props: {
+        msg: 'Mensaje de prueba'
+      }
+    });
+
+    expect(wrapper.text()).toContain('Mensaje de prueba');
+  });
+});

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.node.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    },
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true,
+    "strict": true,
+    "types": ["node", "vite/client"]
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath, URL } from 'node:url';
+
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  }
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath, URL } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true
+  }
+});

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,4 @@
+# Scripts de base de datos
+
+Este directorio está destinado a almacenar scripts de Microsoft SQL Server (MSSQL) relacionados con el
+proyecto. Puedes añadir aquí archivos `.sql` organizados por subcarpetas según tus necesidades.


### PR DESCRIPTION
## Summary
- add a Vue 3 + TypeScript frontend configured with Tailwind CSS, routing, state management, and testing tooling
- scaffold an ASP.NET Core 8 minimal API backend with in-memory CRUD endpoints and Swagger support
- create a scripts directory for future MSSQL scripts and update repository documentation

## Testing
- not run (tooling dependencies not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dec5ac85a4832cb0a09fcf4c17c59d