### PR TITLE
Implement main menu dashboard and login error modal

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -13,114 +13,97 @@ const logout = () => {
   authStore.logout();
   router.push({ name: 'login' });
 };
+
+const menuSections = [
+  {
+    name: 'Consultas',
+    icon: '🩺',
+    description: 'Gestiona la atención diaria de pacientes y el seguimiento clínico.',
+    items: [
+      {
+        title: 'Crear consulta',
+        detail: 'Registra una nueva consulta, asigna profesionales y prepara el consultorio.'
+      },
+      {
+        title: 'Historial de consultas',
+        detail: 'Explora consultas anteriores, notas médicas y evolución de pacientes.'
+      }
+    ]
+  },
+  {
+    name: 'Administración',
+    icon: '🛠️',
+    description: 'Organiza el equipo y la operación administrativa del consultorio.',
+    items: [
+      {
+        title: 'Usuarios',
+        detail: 'Gestiona cuentas, restablece contraseñas y define roles de acceso.'
+      },
+      {
+        title: 'Médicos',
+        detail: 'Actualiza información profesional, especialidades y disponibilidad.'
+      }
+    ]
+  }
+];
 </script>
 
 <template>
   <main class="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-emerald-950 px-4 py-10">
-    <div class="mx-auto flex max-w-6xl flex-col gap-10">
-      <header class="flex flex-col justify-between gap-6 rounded-3xl border border-emerald-500/20 bg-slate-950/80 p-8 shadow-2xl shadow-emerald-500/10 backdrop-blur">
-        <div class="flex flex-col gap-2 text-center md:flex-row md:items-center md:justify-between md:text-left">
+    <div class="mx-auto flex max-w-5xl flex-col gap-10">
+      <header class="flex flex-col gap-6 rounded-3xl border border-emerald-500/20 bg-slate-950/80 p-8 shadow-2xl shadow-emerald-500/10 backdrop-blur">
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
             <p class="text-sm uppercase tracking-[0.3em] text-emerald-300">Consultorio Integral</p>
-            <h1 class="text-3xl font-bold text-white md:text-4xl">Panel de gestión clínica</h1>
+            <h1 class="text-3xl font-bold text-white md:text-4xl">Menú principal</h1>
+            <p class="mt-3 max-w-2xl text-sm text-slate-300">
+              Selecciona un módulo para comenzar a trabajar. Desde aquí podrás registrar nuevas consultas, revisar historiales y administrar el equipo del consultorio.
+            </p>
           </div>
-          <div class="rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-5 py-3 text-sm text-emerald-100">
-            Sesión iniciada como <span class="font-semibold text-white">{{ nombre }}</span>
-            <span class="ml-1 text-emerald-300">({{ usuario }})</span>
+          <div class="flex flex-col items-start gap-3 text-sm text-emerald-100 md:items-end">
+            <div class="rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-5 py-3">
+              Sesión iniciada como <span class="font-semibold text-white">{{ nombre }}</span>
+              <span class="ml-1 text-emerald-300">({{ usuario }})</span>
+            </div>
+            <button
+              class="inline-flex items-center justify-center rounded-xl border border-emerald-400/60 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-200 transition hover:bg-emerald-500/10"
+              type="button"
+              @click="logout"
+            >
+              Cerrar sesión
+            </button>
           </div>
-        </div>
-        <div class="flex flex-wrap items-center justify-between gap-4 text-slate-300">
-          <p class="max-w-2xl text-sm">
-            Desde este panel puedes gestionar la operación diaria del consultorio: revisar agenda médica, monitorear pacientes
-            en seguimiento, coordinar personal y mantener informada a la administración.
-          </p>
-          <button
-            class="rounded-xl border border-emerald-400/60 px-4 py-2 text-sm font-semibold uppercase tracking-wide text-emerald-200 transition hover:bg-emerald-500/10"
-            type="button"
-            @click="logout"
-          >
-            Cerrar sesión
-          </button>
         </div>
       </header>
 
-      <section class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-        <article class="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 shadow-xl shadow-slate-950/40">
-          <h2 class="text-lg font-semibold text-white">Agenda del día</h2>
-          <p class="mt-2 text-sm text-slate-300">
-            Visualiza las citas programadas por especialidad, confirma asistencias y agrega nuevos pacientes en minutos.
-          </p>
-          <ul class="mt-4 space-y-2 text-sm text-slate-400">
-            <li>08:30 - Consulta general · Sala 2</li>
-            <li>10:15 - Control prenatal · Sala 1</li>
-            <li>12:00 - Terapia física · Sala 3</li>
-          </ul>
-        </article>
-
-        <article class="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 shadow-xl shadow-slate-950/40">
-          <h2 class="text-lg font-semibold text-white">Pacientes en seguimiento</h2>
-          <p class="mt-2 text-sm text-slate-300">
-            Consulta los indicadores clave y actualiza el estado clínico de pacientes crónicos o en tratamientos prolongados.
-          </p>
-          <ul class="mt-4 space-y-2 text-sm text-slate-400">
-            <li>María Gómez · Control de diabetes</li>
-            <li>José Ramírez · Rehabilitación postoperatoria</li>
-            <li>Daniela Ruiz · Seguimiento pediátrico</li>
-          </ul>
-        </article>
-
-        <article class="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 shadow-xl shadow-slate-950/40">
-          <h2 class="text-lg font-semibold text-white">Indicadores del consultorio</h2>
-          <p class="mt-2 text-sm text-slate-300">
-            Monitorea la ocupación de consultorios, tiempos promedio de atención y desempeño del equipo médico.
-          </p>
-          <div class="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-300">
-            <div class="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-3 text-center">
-              <p class="text-2xl font-bold text-emerald-300">85%</p>
-              <p>Ocupación</p>
-            </div>
-            <div class="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-3 text-center">
-              <p class="text-2xl font-bold text-emerald-300">18m</p>
-              <p>Promedio atención</p>
-            </div>
-            <div class="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-3 text-center">
-              <p class="text-2xl font-bold text-emerald-300">92%</p>
-              <p>Satisfacción</p>
-            </div>
-            <div class="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-3 text-center">
-              <p class="text-2xl font-bold text-emerald-300">+12</p>
-              <p>Nuevos pacientes</p>
+      <section class="grid gap-6 md:grid-cols-2">
+        <article
+          v-for="section in menuSections"
+          :key="section.name"
+          class="flex flex-col gap-5 rounded-3xl border border-slate-800/80 bg-slate-950/70 p-8 shadow-xl shadow-slate-950/40"
+        >
+          <div class="flex items-start gap-4">
+            <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-2xl">{{ section.icon }}</span>
+            <div>
+              <h2 class="text-xl font-semibold text-white">{{ section.name }}</h2>
+              <p class="mt-2 text-sm text-slate-300">{{ section.description }}</p>
             </div>
           </div>
-        </article>
-      </section>
 
-      <section class="grid gap-6 rounded-3xl border border-emerald-500/10 bg-slate-950/60 p-8 md:grid-cols-2">
-        <div class="space-y-4">
-          <h2 class="text-xl font-semibold text-white">Protocolos destacados</h2>
-          <ul class="space-y-3 text-sm text-slate-300">
-            <li class="flex items-start gap-3">
-              <span class="mt-1 text-emerald-300">✅</span>
-              <span>Verifica signos vitales y actualiza el expediente antes de iniciar cualquier consulta.</span>
-            </li>
-            <li class="flex items-start gap-3">
-              <span class="mt-1 text-emerald-300">🩺</span>
-              <span>Registra indicaciones médicas y prescripciones electrónicas en el mismo momento de la consulta.</span>
-            </li>
-            <li class="flex items-start gap-3">
-              <span class="mt-1 text-emerald-300">💊</span>
-              <span>Coordina con farmacia interna la disponibilidad de tratamientos recetados.</span>
+          <ul class="space-y-4">
+            <li
+              v-for="item in section.items"
+              :key="item.title"
+              class="group rounded-2xl border border-slate-800 bg-slate-900/80 p-5 transition hover:border-emerald-500/60 hover:bg-emerald-500/5"
+            >
+              <div class="flex items-center justify-between">
+                <p class="text-base font-semibold text-white">{{ item.title }}</p>
+                <span class="text-sm text-emerald-300 transition group-hover:translate-x-1">➔</span>
+              </div>
+              <p class="mt-2 text-sm text-slate-400">{{ item.detail }}</p>
             </li>
           </ul>
-        </div>
-        <div class="space-y-4">
-          <h2 class="text-xl font-semibold text-white">Contacto rápido</h2>
-          <div class="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 text-sm text-slate-300">
-            <p><span class="font-semibold text-white">Soporte técnico:</span> soporte@consultorio.mx</p>
-            <p class="mt-2"><span class="font-semibold text-white">Teléfono interno:</span> Ext. 203</p>
-            <p class="mt-2"><span class="font-semibold text-white">Horario de atención:</span> Lunes a viernes · 8:00 a 18:00 h</p>
-          </div>
-        </div>
+        </article>
       </section>
     </div>
   </main>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -13,11 +13,14 @@ const credentials = reactive({
 
 const loading = ref(false);
 const errorMessage = ref('');
+const showErrorModal = ref(false);
 
 const apiBase = import.meta.env.VITE_API_BASE ?? 'http://localhost:5207';
+const invalidCredentialsMessage = 'usuario o contraseña no validos';
 
 const handleSubmit = async () => {
   errorMessage.value = '';
+  showErrorModal.value = false;
   loading.value = true;
 
   try {
@@ -30,9 +33,7 @@ const handleSubmit = async () => {
     });
 
     if (!response.ok) {
-      const payload = await response.json().catch(() => ({}));
-      const message = 'Credenciales inválidas o usuario inactivo.';
-      throw new Error(payload.message ?? message);
+      throw new Error(invalidCredentialsMessage);
     }
 
     const data = await response.json();
@@ -40,13 +41,18 @@ const handleSubmit = async () => {
     router.push({ name: 'dashboard' });
   } catch (error) {
     if (error instanceof Error) {
-      errorMessage.value = error.message;
+      errorMessage.value = error.message === invalidCredentialsMessage ? invalidCredentialsMessage : 'Ocurrió un error inesperado. Intenta de nuevo.';
     } else {
       errorMessage.value = 'Ocurrió un error inesperado. Intenta de nuevo.';
     }
+    showErrorModal.value = true;
   } finally {
     loading.value = false;
   }
+};
+
+const closeErrorModal = () => {
+  showErrorModal.value = false;
 };
 </script>
 
@@ -59,8 +65,7 @@ const handleSubmit = async () => {
             <p class="text-sm uppercase tracking-[0.3em] text-emerald-300">Consultorio Integral</p>
             <h1 class="mt-3 text-3xl font-bold text-white md:text-4xl">Acceso al panel clínico</h1>
             <p class="mt-4 text-sm leading-relaxed text-slate-300">
-              Administra citas, expedientes y seguimientos desde un único lugar. Ingresa con tu usuario asignado por la
-              administración del consultorio.
+              Administra citas, expedientes y seguimientos desde un único lugar. Ingresa con tu usuario asignado por la administración del consultorio.
             </p>
           </div>
           <ul class="space-y-3 text-sm text-slate-300">
@@ -120,18 +125,29 @@ const handleSubmit = async () => {
               <span v-if="!loading">Ingresar</span>
               <span v-else>Validando...</span>
             </button>
-
-            <p v-if="errorMessage" class="rounded-lg border border-rose-500/60 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
-              {{ errorMessage }}
-            </p>
           </form>
 
           <p class="text-xs text-slate-500">
-            ¿Necesitas ayuda? Contacta al área de soporte del consultorio para recuperar tu acceso o solicitar un nuevo
-            usuario.
+            ¿Necesitas ayuda? Contacta al área de soporte del consultorio para recuperar tu acceso o solicitar un nuevo usuario.
           </p>
         </section>
       </div>
     </div>
+
+    <transition name="fade">
+      <div v-if="showErrorModal" class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4">
+        <div class="w-full max-w-sm rounded-2xl border border-rose-500/40 bg-slate-900 p-6 text-center shadow-2xl shadow-rose-500/20">
+          <h3 class="text-lg font-semibold text-white">Inicio de sesión</h3>
+          <p class="mt-3 text-sm text-rose-200">{{ errorMessage || invalidCredentialsMessage }}</p>
+          <button
+            class="mt-6 inline-flex items-center justify-center rounded-xl bg-emerald-500 px-5 py-2 text-sm font-semibold uppercase tracking-wide text-slate-950 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/60"
+            type="button"
+            @click="closeErrorModal"
+          >
+            Aceptar
+          </button>
+        </div>
+      </div>
+    </transition>
   </main>
 </template>


### PR DESCRIPTION
## Summary
- show a modal when login fails so the user can acknowledge invalid credentials
- replace the dashboard content with a main menu that groups consultas and administración options

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68deffa92104832caafc159cfe48d175