### PR TITLE
Add Visual Studio solution for backend

### DIFF
--- a/backend/BackendApi.sln
+++ b/backend/BackendApi.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackendApi", "BackendApi.csproj", "{43F0A492-917D-48D2-B5EB-02EC33E29E8C}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {43F0A492-917D-48D2-B5EB-02EC33E29E8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {43F0A492-917D-48D2-B5EB-02EC33E29E8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {43F0A492-917D-48D2-B5EB-02EC33E29E8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {43F0A492-917D-48D2-B5EB-02EC33E29E8C}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+    GlobalSection(ExtensibilityGlobals) = postSolution
+        SolutionGuid = {CBE3D15E-9BCC-4BD4-8605-C7243FCBA3F0}
+    EndGlobalSection
+EndGlobal

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,9 +7,16 @@ C#.
 
 ```bash
 cd backend
- dotnet restore
- dotnet run
+dotnet restore
+dotnet run
 ```
 
 La API expone endpoints básicos para gestionar tareas en memoria y cuenta con documentación generada
 por Swagger en `/swagger` cuando se ejecuta en modo desarrollo.
+
+## Apertura en Visual Studio 2022
+
+1. Abrir Visual Studio 2022.
+2. Seleccionar **Archivo > Abrir > Proyecto o solución...**.
+3. Navegar a la carpeta `backend` y elegir el archivo `BackendApi.sln`.
+4. Visual Studio cargará automáticamente el proyecto web `BackendApi` listo para compilarse y ejecutarse.


### PR DESCRIPTION
## Summary
- add a Visual Studio solution file so the backend can be opened directly in Visual Studio 2022
- document the steps to open the backend solution from Visual Studio 2022

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df05e7b0e4832ca0f8c382f5b06c23