### PR TITLE
Add missing EF Core and OpenAPI package references

### DIFF
--- a/backend/BackendApi.csproj
+++ b/backend/BackendApi.csproj
@@ -4,4 +4,10 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add OpenAPI and Entity Framework Core package references required by Program.cs
- include in-memory provider to support the configured data context

## Testing
- not run (dotnet CLI is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68df0cb0769c832cb8c56a5ca51ae9ee