### PR TITLE
Fix missing dependency injection namespace import

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 


### PR DESCRIPTION
## Summary
- add the Microsoft.Extensions.DependencyInjection namespace import so dependency injection extension methods are available in Program.cs

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df0db1f4cc832c81a41081e9f2c34c