### PR TITLE
Update login API base URL

### DIFF
--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -15,7 +15,7 @@ const loading = ref(false);
 const errorMessage = ref('');
 const showErrorModal = ref(false);
 
-const apiBase = import.meta.env.VITE_API_BASE ?? 'http://localhost:5207';
+const apiBase = import.meta.env.VITE_API_BASE ?? 'https://localhost:59831';
 const invalidCredentialsMessage = 'usuario o contraseña no validos';
 
 const handleSubmit = async () => {


### PR DESCRIPTION
## Summary
- point the login view to the new default API base URL at https://localhost:59831 when no environment override is provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df1a91a100832cb1f82fa77206d99e