### PR TITLE
Switch backend to SQL Server EF provider

### DIFF
--- a/backend/BackendApi.csproj
+++ b/backend/BackendApi.csproj
@@ -13,6 +13,6 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -25,7 +25,7 @@ var connectionString = builder.Configuration.GetConnectionString("Consultorio")
     ?? throw new InvalidOperationException("Connection string 'Consultorio' not found.");
 
 builder.Services.AddDbContext<ConsultorioDbContext>(options =>
-    options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString)));
+    options.UseSqlServer(connectionString));
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- configure the Consultorio DbContext to use the SQL Server provider instead of MySQL
- replace the Pomelo MySQL package with Microsoft.EntityFrameworkCore.SqlServer

## Testing
- dotnet restore BackendApi.sln *(fails: dotnet CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df1eac4bac832caa76656038e1519b