### PR TITLE
Fix SQL Server certificate trust issue

### DIFF
--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -7,6 +7,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "Consultorio": "Server=localhost;User Id=sa;Password=triplea;Database=bdmedica;TreatTinyAsBoolean=true;"
+    "Consultorio": "Server=localhost;User Id=sa;Password=triplea;Database=bdmedica;TreatTinyAsBoolean=true;Encrypt=False;TrustServerCertificate=True;"
   }
 }


### PR DESCRIPTION
## Summary
- update the SQL Server connection string to trust the server certificate and disable encryption to prevent SSL provider login errors

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e028eba070832cbe2090b1c2eac574