### PR TITLE
Implement JWT-secured minimal API for consultorio management

### DIFF
--- a/backend/BackendApi.csproj
+++ b/backend/BackendApi.csproj
@@ -10,9 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/backend/Contracts/ConsultaDtos.cs
+++ b/backend/Contracts/ConsultaDtos.cs
@@ -1,0 +1,18 @@
+namespace Backend.Contracts;
+
+public sealed record CreateConsultaRequest(
+    int MedicoId,
+    int PacienteId,
+    DateTime FechaConsulta,
+    string? Sintomas,
+    string? Recomendaciones,
+    string? Diagnostico);
+
+public sealed record ConsultaResponse(
+    int Id,
+    int MedicoId,
+    int PacienteId,
+    DateTime FechaConsulta,
+    string? Sintomas,
+    string? Recomendaciones,
+    string? Diagnostico);

--- a/backend/Contracts/LoginRequest.cs
+++ b/backend/Contracts/LoginRequest.cs
@@ -1,3 +1,3 @@
 namespace Backend.Contracts;
 
-public sealed record LoginRequest(string Usuario, string Contrasena);
+public sealed record LoginRequest(string Correo, string Password);

--- a/backend/Contracts/LoginResponse.cs
+++ b/backend/Contracts/LoginResponse.cs
@@ -1,3 +1,5 @@
 namespace Backend.Contracts;
 
-public sealed record LoginResponse(int Id, string Usuario, string Nombre);
+public sealed record LoginResponse(string Token, DateTime Expiracion, UsuarioSummary Usuario);
+
+public sealed record UsuarioSummary(int Id, string Correo, string NombreCompleto, int? MedicoId);

--- a/backend/Contracts/MedicoDtos.cs
+++ b/backend/Contracts/MedicoDtos.cs
@@ -1,0 +1,25 @@
+namespace Backend.Contracts;
+
+public sealed record CreateMedicoRequest(
+    string PrimerNombre,
+    string? SegundoNombre,
+    string ApellidoPaterno,
+    string? ApellidoMaterno,
+    string Cedula,
+    string? Telefono,
+    string? Especialidad,
+    string? Email,
+    bool Activo);
+
+public sealed record MedicoResponse(
+    int Id,
+    string PrimerNombre,
+    string? SegundoNombre,
+    string ApellidoPaterno,
+    string? ApellidoMaterno,
+    string Cedula,
+    string? Telefono,
+    string? Especialidad,
+    string? Email,
+    bool Activo,
+    DateTime FechaCreacion);

--- a/backend/Contracts/PacienteDtos.cs
+++ b/backend/Contracts/PacienteDtos.cs
@@ -1,0 +1,19 @@
+namespace Backend.Contracts;
+
+public sealed record CreatePacienteRequest(
+    string PrimerNombre,
+    string? SegundoNombre,
+    string ApellidoPaterno,
+    string? ApellidoMaterno,
+    string? Telefono,
+    bool Activo);
+
+public sealed record PacienteResponse(
+    int Id,
+    string PrimerNombre,
+    string? SegundoNombre,
+    string ApellidoPaterno,
+    string? ApellidoMaterno,
+    string? Telefono,
+    bool Activo,
+    DateTime FechaCreacion);

--- a/backend/Contracts/UsuarioDtos.cs
+++ b/backend/Contracts/UsuarioDtos.cs
@@ -1,0 +1,5 @@
+namespace Backend.Contracts;
+
+public sealed record CreateUsuarioRequest(string Correo, string Password, string NombreCompleto, int? MedicoId, bool Activo);
+
+public sealed record UsuarioResponse(int Id, string Correo, string NombreCompleto, int? MedicoId, bool Activo, DateTime FechaCreacion);

--- a/backend/Data/ConsultorioDbContext.cs
+++ b/backend/Data/ConsultorioDbContext.cs
@@ -1,60 +1,48 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Backend.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Data;
 
-public sealed class ConsultorioDbContext : DbContext
+public sealed class ConsultorioDbContext(DbContextOptions<ConsultorioDbContext> options) : DbContext(options)
 {
-    public ConsultorioDbContext(DbContextOptions<ConsultorioDbContext> options)
-        : base(options)
-    {
-    }
-
     public DbSet<Usuario> Usuarios => Set<Usuario>();
-
-    public Task<Usuario?> FindUsuarioAsync(string normalizedUsuario, CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrWhiteSpace(normalizedUsuario))
-        {
-            return Task.FromResult<Usuario?>(null);
-        }
-
-        var normalized = normalizedUsuario.Trim().ToLowerInvariant();
-
-        return Usuarios
-            .AsNoTracking()
-            .FirstOrDefaultAsync(usuario => usuario.NombreUsuario.ToLower() == normalized, cancellationToken);
-    }
+    public DbSet<Medico> Medicos => Set<Medico>();
+    public DbSet<Paciente> Pacientes => Set<Paciente>();
+    public DbSet<Consulta> Consultas => Set<Consulta>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
 
+        modelBuilder.Entity<Medico>(entity =>
+        {
+            entity.HasIndex(m => m.Cedula).IsUnique();
+            entity.HasIndex(m => m.Email).IsUnique();
+        });
+
         modelBuilder.Entity<Usuario>(entity =>
         {
-            entity.ToTable("usuarios");
+            entity.HasIndex(u => u.Correo).IsUnique();
 
-            entity.HasKey(usuario => usuario.IdUsuarios);
+            entity.HasOne(u => u.Medico)
+                  .WithMany(m => m.Usuarios)
+                  .HasForeignKey(u => u.MedicoId)
+                  .OnDelete(DeleteBehavior.SetNull);
+        });
 
-            entity.Property(usuario => usuario.IdUsuarios)
-                  .HasColumnName("idUsuarios");
+        modelBuilder.Entity<Paciente>();
 
-            entity.Property(usuario => usuario.NombreUsuario)
-                  .HasColumnName("nombreUsuario")
-                  .HasMaxLength(100);
+        modelBuilder.Entity<Consulta>(entity =>
+        {
+            entity.HasOne(c => c.Medico)
+                  .WithMany(m => m.Consultas)
+                  .HasForeignKey(c => c.MedicoId)
+                  .OnDelete(DeleteBehavior.Restrict);
 
-            entity.Property(usuario => usuario.Nombre)
-                  .HasColumnName("nombre")
-                  .HasMaxLength(150);
-
-            entity.Property(usuario => usuario.Contrasena)
-                  .HasColumnName("contrasena")
-                  .HasMaxLength(255);
-
-            entity.Property(usuario => usuario.Activo)
-                  .HasColumnName("activo");
+            entity.HasOne(c => c.Paciente)
+                  .WithMany(p => p.Consultas)
+                  .HasForeignKey(c => c.PacienteId)
+                  .OnDelete(DeleteBehavior.Restrict);
         });
     }
 }

--- a/backend/Models/Consulta.cs
+++ b/backend/Models/Consulta.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Backend.Models;
+
+[Table("consultas")]
+public class Consulta
+{
+    [Key]
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("id_medico")]
+    public int MedicoId { get; set; }
+
+    [Column("id_paciente")]
+    public int PacienteId { get; set; }
+
+    [Column("fecha_consulta")]
+    public DateTime FechaConsulta { get; set; }
+
+    [Column("sintomas")]
+    [MaxLength(500)]
+    public string? Sintomas { get; set; }
+
+    [Column("recomendaciones")]
+    [MaxLength(500)]
+    public string? Recomendaciones { get; set; }
+
+    [Column("diagnostico")]
+    [MaxLength(500)]
+    public string? Diagnostico { get; set; }
+
+    public Medico? Medico { get; set; }
+
+    public Paciente? Paciente { get; set; }
+}

--- a/backend/Models/Medico.cs
+++ b/backend/Models/Medico.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Backend.Models;
+
+[Table("medicos")]
+public class Medico
+{
+    [Key]
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Required]
+    [Column("primer_nombre")]
+    [MaxLength(100)]
+    public string PrimerNombre { get; set; } = string.Empty;
+
+    [Column("segundo_nombre")]
+    [MaxLength(100)]
+    public string? SegundoNombre { get; set; }
+
+    [Required]
+    [Column("apellido_paterno")]
+    [MaxLength(100)]
+    public string ApellidoPaterno { get; set; } = string.Empty;
+
+    [Column("apellido_materno")]
+    [MaxLength(100)]
+    public string? ApellidoMaterno { get; set; }
+
+    [Required]
+    [Column("cedula")]
+    [MaxLength(50)]
+    public string Cedula { get; set; } = string.Empty;
+
+    [Column("telefono")]
+    [MaxLength(20)]
+    public string? Telefono { get; set; }
+
+    [Column("especialidad")]
+    [MaxLength(150)]
+    public string? Especialidad { get; set; }
+
+    [Column("email")]
+    [MaxLength(150)]
+    public string? Email { get; set; }
+
+    [Column("activo")]
+    public bool Activo { get; set; }
+
+    [Column("fecha_creacion")]
+    public DateTime FechaCreacion { get; set; }
+
+    public ICollection<Usuario> Usuarios { get; set; } = new List<Usuario>();
+
+    public ICollection<Consulta> Consultas { get; set; } = new List<Consulta>();
+}

--- a/backend/Models/Paciente.cs
+++ b/backend/Models/Paciente.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Backend.Models;
+
+[Table("pacientes")]
+public class Paciente
+{
+    [Key]
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Required]
+    [Column("primer_nombre")]
+    [MaxLength(100)]
+    public string PrimerNombre { get; set; } = string.Empty;
+
+    [Column("segundo_nombre")]
+    [MaxLength(100)]
+    public string? SegundoNombre { get; set; }
+
+    [Required]
+    [Column("apellido_paterno")]
+    [MaxLength(100)]
+    public string ApellidoPaterno { get; set; } = string.Empty;
+
+    [Column("apellido_materno")]
+    [MaxLength(100)]
+    public string? ApellidoMaterno { get; set; }
+
+    [Column("telefono")]
+    [MaxLength(20)]
+    public string? Telefono { get; set; }
+
+    [Column("activo")]
+    public bool Activo { get; set; }
+
+    [Column("fecha_creacion")]
+    public DateTime FechaCreacion { get; set; }
+
+    public ICollection<Consulta> Consultas { get; set; } = new List<Consulta>();
+}

--- a/backend/Models/Usuario.cs
+++ b/backend/Models/Usuario.cs
@@ -1,14 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace Backend.Models;
 
+[Table("usuarios")]
 public class Usuario
 {
-    public int IdUsuarios { get; set; }
+    [Key]
+    [Column("id")]
+    public int Id { get; set; }
 
-    public string NombreUsuario { get; set; } = string.Empty;
+    [Required]
+    [Column("correo")]
+    [MaxLength(150)]
+    public string Correo { get; set; } = string.Empty;
 
-    public string Nombre { get; set; } = string.Empty;
+    [Required]
+    [Column("password")]
+    [MaxLength(512)]
+    public string PasswordHash { get; set; } = string.Empty;
 
-    public string Contrasena { get; set; } = string.Empty;
+    [Required]
+    [Column("nombre_completo")]
+    [MaxLength(200)]
+    public string NombreCompleto { get; set; } = string.Empty;
 
+    [Column("id_medico")]
+    public int? MedicoId { get; set; }
+
+    [Column("activo")]
     public bool Activo { get; set; }
+
+    [Column("fecha_creacion")]
+    public DateTime FechaCreacion { get; set; }
+
+    public Medico? Medico { get; set; }
 }

--- a/backend/Options/JwtSettings.cs
+++ b/backend/Options/JwtSettings.cs
@@ -1,0 +1,9 @@
+namespace Backend.Options;
+
+public sealed class JwtSettings
+{
+    public string Key { get; set; } = string.Empty;
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public int ExpiresMinutes { get; set; } = 60;
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,31 +1,85 @@
-using System.Threading;
+using System.Text;
 using Backend.Contracts;
 using Backend.Data;
 using Backend.Models;
-using Microsoft.AspNetCore.Builder;
+using Backend.Options;
+using Backend.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
-
-builder.Services.AddCors(options =>
-{
-    options.AddDefaultPolicy(policy =>
-        policy.AllowAnyOrigin()
-              .AllowAnyMethod()
-              .AllowAnyHeader());
-});
-
-var connectionString = builder.Configuration.GetConnectionString("Consultorio")
-    ?? throw new InvalidOperationException("Connection string 'Consultorio' not found.");
+var configuration = builder.Configuration;
 
 builder.Services.AddDbContext<ConsultorioDbContext>(options =>
-    options.UseSqlServer(connectionString));
+    options.UseSqlServer(configuration.GetConnectionString("Consultorio")));
+
+builder.Services.Configure<JwtSettings>(configuration.GetSection("Jwt"));
+builder.Services.AddSingleton<IJwtTokenService, JwtTokenService>();
+builder.Services.AddSingleton<IPasswordService, PasswordService>();
+
+var jwtSettings = configuration.GetSection("Jwt").Get<JwtSettings>()
+                 ?? throw new InvalidOperationException("La configuración de JWT es obligatoria.");
+
+if (string.IsNullOrWhiteSpace(jwtSettings.Key))
+{
+    throw new InvalidOperationException("La clave JWT no está configurada.");
+}
+
+var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.Key));
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidateIssuerSigningKey = true,
+        ValidateLifetime = true,
+        ValidIssuer = jwtSettings.Issuer,
+        ValidAudience = jwtSettings.Audience,
+        IssuerSigningKey = signingKey,
+        ClockSkew = TimeSpan.Zero
+    };
+});
+
+builder.Services.AddAuthorization();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "Consultorio API",
+        Version = "v1",
+        Description = "API minimal para gestionar consultorios médicos"
+    });
+
+    var securityScheme = new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = JwtBearerDefaults.AuthenticationScheme,
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "Introduce el token JWT usando el esquema Bearer"
+    };
+
+    options.AddSecurityDefinition("Bearer", securityScheme);
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            securityScheme,
+            Array.Empty<string>()
+        }
+    });
+});
 
 var app = builder.Build();
 
@@ -35,7 +89,8 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-app.UseCors();
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapGet("/", () =>
 {
@@ -49,29 +104,24 @@ app.MapGet("/", () =>
     }
     catch (Exception ex)
     {
-        return Results.Json(new
-        {
-            message = $"Ocurrió un error al obtener la información de la API. {ex.Message}",
-            detail = ex.Message
-        }, statusCode: StatusCodes.Status500InternalServerError);
+        return Results.Problem($"Ocurrió un error al obtener la información de la API. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
     }
-})
-   .WithName("GetRoot");
+}).WithName("GetRoot");
 
-app.MapPost("/auth/login", async (ConsultorioDbContext db, LoginRequest request, CancellationToken cancellationToken) =>
+app.MapPost("/auth/login", async (
+    LoginRequest request,
+    ConsultorioDbContext db,
+    IPasswordService passwordService,
+    IJwtTokenService tokenService) =>
 {
     try
     {
-        if (string.IsNullOrWhiteSpace(request.Usuario) || string.IsNullOrWhiteSpace(request.Contrasena))
-        {
-            return Results.BadRequest(new { message = "Usuario y contraseña son obligatorios." });
-        }
+        var correoNormalizado = request.Correo.Trim().ToLowerInvariant();
+        var usuario = await db.Usuarios
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Correo.ToLower() == correoNormalizado);
 
-        var normalizedUser = request.Usuario.Trim().ToLowerInvariant();
-
-        var usuario = await db.FindUsuarioAsync(normalizedUser, cancellationToken);
-
-        if (usuario is null || !string.Equals(usuario.Contrasena, request.Contrasena))
+        if (usuario is null)
         {
             return Results.Json(new { message = "Credenciales inválidas." }, statusCode: StatusCodes.Status401Unauthorized);
         }
@@ -81,19 +131,409 @@ app.MapPost("/auth/login", async (ConsultorioDbContext db, LoginRequest request,
             return Results.Json(new { message = "El usuario se encuentra inactivo." }, statusCode: StatusCodes.Status401Unauthorized);
         }
 
-        var response = new LoginResponse(usuario.IdUsuarios, usuario.NombreUsuario, usuario.Nombre);
+        if (!passwordService.VerifyPassword(usuario.PasswordHash, request.Password))
+        {
+            return Results.Json(new { message = "Credenciales inválidas." }, statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        var token = tokenService.GenerateToken(usuario);
+        var response = new LoginResponse(
+            token.Token,
+            token.Expiration,
+            new UsuarioSummary(usuario.Id, usuario.Correo, usuario.NombreCompleto, usuario.MedicoId));
+
         return Results.Ok(response);
     }
     catch (Exception ex)
     {
-        return Results.Json(new
-        {
-            message = $"Ocurrió un error al iniciar sesión. {ex.Message}",
-            detail = ex.Message
-        }, statusCode: StatusCodes.Status500InternalServerError);
+        return Results.Problem($"Ocurrió un error al iniciar sesión. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
     }
-})
-   .WithName("Login")
-   .WithOpenApi();
+}).WithName("Login").AllowAnonymous();
+
+app.MapPost("/api/usuarios", async (
+    CreateUsuarioRequest request,
+    ConsultorioDbContext db,
+    IPasswordService passwordService) =>
+{
+    try
+    {
+        var correoNormalizado = request.Correo.Trim().ToLowerInvariant();
+        var existeUsuario = await db.Usuarios.AnyAsync(u => u.Correo.ToLower() == correoNormalizado);
+        if (existeUsuario)
+        {
+            return Results.BadRequest(new { message = "El correo electrónico ya se encuentra registrado." });
+        }
+
+        if (request.MedicoId.HasValue)
+        {
+            var medicoExiste = await db.Medicos.AnyAsync(m => m.Id == request.MedicoId.Value);
+            if (!medicoExiste)
+            {
+                return Results.BadRequest(new { message = "El médico asociado no existe." });
+            }
+        }
+
+        var nuevoUsuario = new Usuario
+        {
+            Correo = request.Correo.Trim(),
+            PasswordHash = passwordService.HashPassword(request.Password),
+            NombreCompleto = request.NombreCompleto.Trim(),
+            MedicoId = request.MedicoId,
+            Activo = request.Activo,
+            FechaCreacion = DateTime.UtcNow
+        };
+
+        db.Usuarios.Add(nuevoUsuario);
+        await db.SaveChangesAsync();
+
+        var response = new UsuarioResponse(
+            nuevoUsuario.Id,
+            nuevoUsuario.Correo,
+            nuevoUsuario.NombreCompleto,
+            nuevoUsuario.MedicoId,
+            nuevoUsuario.Activo,
+            nuevoUsuario.FechaCreacion);
+
+        return Results.Created($"/api/usuarios/{nuevoUsuario.Id}", response);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al crear el usuario. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("CreateUsuario").AllowAnonymous();
+
+app.MapGet("/api/usuarios", async (ConsultorioDbContext db) =>
+{
+    try
+    {
+        var usuarios = await db.Usuarios
+            .AsNoTracking()
+            .Select(u => new UsuarioResponse(u.Id, u.Correo, u.NombreCompleto, u.MedicoId, u.Activo, u.FechaCreacion))
+            .ToListAsync();
+
+        return Results.Ok(usuarios);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al consultar los usuarios. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("GetUsuarios").RequireAuthorization();
+
+app.MapGet("/api/usuarios/{id:int}", async (int id, ConsultorioDbContext db) =>
+{
+    try
+    {
+        var usuario = await db.Usuarios
+            .AsNoTracking()
+            .Where(u => u.Id == id)
+            .Select(u => new UsuarioResponse(u.Id, u.Correo, u.NombreCompleto, u.MedicoId, u.Activo, u.FechaCreacion))
+            .FirstOrDefaultAsync();
+
+        return usuario is null
+            ? Results.NotFound()
+            : Results.Ok(usuario);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al consultar el usuario. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("GetUsuario").RequireAuthorization();
+
+app.MapDelete("/api/usuarios/{id:int}", async (int id, ConsultorioDbContext db) =>
+{
+    try
+    {
+        var usuario = await db.Usuarios.FindAsync(id);
+        if (usuario is null)
+        {
+            return Results.NotFound();
+        }
+
+        db.Usuarios.Remove(usuario);
+        await db.SaveChangesAsync();
+
+        return Results.NoContent();
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al eliminar el usuario. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("DeleteUsuario").RequireAuthorization();
+
+app.MapPost("/api/medicos", async (CreateMedicoRequest request, ConsultorioDbContext db) =>
+{
+    try
+    {
+        var cedulaExiste = await db.Medicos.AnyAsync(m => m.Cedula == request.Cedula);
+        if (cedulaExiste)
+        {
+            return Results.BadRequest(new { message = "La cédula ya se encuentra registrada." });
+        }
+
+        var emailExiste = !string.IsNullOrWhiteSpace(request.Email) && await db.Medicos.AnyAsync(m => m.Email == request.Email);
+        if (emailExiste)
+        {
+            return Results.BadRequest(new { message = "El correo electrónico del médico ya se encuentra registrado." });
+        }
+
+        var medico = new Medico
+        {
+            PrimerNombre = request.PrimerNombre.Trim(),
+            SegundoNombre = request.SegundoNombre?.Trim(),
+            ApellidoPaterno = request.ApellidoPaterno.Trim(),
+            ApellidoMaterno = request.ApellidoMaterno?.Trim(),
+            Cedula = request.Cedula.Trim(),
+            Telefono = request.Telefono?.Trim(),
+            Especialidad = request.Especialidad?.Trim(),
+            Email = request.Email?.Trim(),
+            Activo = request.Activo,
+            FechaCreacion = DateTime.UtcNow
+        };
+
+        db.Medicos.Add(medico);
+        await db.SaveChangesAsync();
+
+        var response = new MedicoResponse(
+            medico.Id,
+            medico.PrimerNombre,
+            medico.SegundoNombre,
+            medico.ApellidoPaterno,
+            medico.ApellidoMaterno,
+            medico.Cedula,
+            medico.Telefono,
+            medico.Especialidad,
+            medico.Email,
+            medico.Activo,
+            medico.FechaCreacion);
+
+        return Results.Created($"/api/medicos/{medico.Id}", response);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al crear el médico. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("CreateMedico").RequireAuthorization();
+
+app.MapGet("/api/medicos", async (ConsultorioDbContext db) =>
+{
+    try
+    {
+        var medicos = await db.Medicos
+            .AsNoTracking()
+            .Select(m => new MedicoResponse(
+                m.Id,
+                m.PrimerNombre,
+                m.SegundoNombre,
+                m.ApellidoPaterno,
+                m.ApellidoMaterno,
+                m.Cedula,
+                m.Telefono,
+                m.Especialidad,
+                m.Email,
+                m.Activo,
+                m.FechaCreacion))
+            .ToListAsync();
+
+        return Results.Ok(medicos);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al consultar los médicos. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("GetMedicos").RequireAuthorization();
+
+app.MapDelete("/api/medicos/{id:int}", async (int id, ConsultorioDbContext db) =>
+{
+    try
+    {
+        var medico = await db.Medicos.FindAsync(id);
+        if (medico is null)
+        {
+            return Results.NotFound();
+        }
+
+        db.Medicos.Remove(medico);
+        await db.SaveChangesAsync();
+
+        return Results.NoContent();
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al eliminar el médico. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("DeleteMedico").RequireAuthorization();
+
+app.MapPost("/api/pacientes", async (CreatePacienteRequest request, ConsultorioDbContext db) =>
+{
+    try
+    {
+        var paciente = new Paciente
+        {
+            PrimerNombre = request.PrimerNombre.Trim(),
+            SegundoNombre = request.SegundoNombre?.Trim(),
+            ApellidoPaterno = request.ApellidoPaterno.Trim(),
+            ApellidoMaterno = request.ApellidoMaterno?.Trim(),
+            Telefono = request.Telefono?.Trim(),
+            Activo = request.Activo,
+            FechaCreacion = DateTime.UtcNow
+        };
+
+        db.Pacientes.Add(paciente);
+        await db.SaveChangesAsync();
+
+        var response = new PacienteResponse(
+            paciente.Id,
+            paciente.PrimerNombre,
+            paciente.SegundoNombre,
+            paciente.ApellidoPaterno,
+            paciente.ApellidoMaterno,
+            paciente.Telefono,
+            paciente.Activo,
+            paciente.FechaCreacion);
+
+        return Results.Created($"/api/pacientes/{paciente.Id}", response);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al crear el paciente. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("CreatePaciente").RequireAuthorization();
+
+app.MapGet("/api/pacientes", async (ConsultorioDbContext db) =>
+{
+    try
+    {
+        var pacientes = await db.Pacientes
+            .AsNoTracking()
+            .Select(p => new PacienteResponse(
+                p.Id,
+                p.PrimerNombre,
+                p.SegundoNombre,
+                p.ApellidoPaterno,
+                p.ApellidoMaterno,
+                p.Telefono,
+                p.Activo,
+                p.FechaCreacion))
+            .ToListAsync();
+
+        return Results.Ok(pacientes);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al consultar los pacientes. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("GetPacientes").RequireAuthorization();
+
+app.MapDelete("/api/pacientes/{id:int}", async (int id, ConsultorioDbContext db) =>
+{
+    try
+    {
+        var paciente = await db.Pacientes.FindAsync(id);
+        if (paciente is null)
+        {
+            return Results.NotFound();
+        }
+
+        db.Pacientes.Remove(paciente);
+        await db.SaveChangesAsync();
+
+        return Results.NoContent();
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al eliminar el paciente. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("DeletePaciente").RequireAuthorization();
+
+app.MapPost("/api/consultas", async (CreateConsultaRequest request, ConsultorioDbContext db) =>
+{
+    try
+    {
+        var medicoExiste = await db.Medicos.AnyAsync(m => m.Id == request.MedicoId);
+        if (!medicoExiste)
+        {
+            return Results.BadRequest(new { message = "El médico especificado no existe." });
+        }
+
+        var pacienteExiste = await db.Pacientes.AnyAsync(p => p.Id == request.PacienteId);
+        if (!pacienteExiste)
+        {
+            return Results.BadRequest(new { message = "El paciente especificado no existe." });
+        }
+
+        var consulta = new Consulta
+        {
+            MedicoId = request.MedicoId,
+            PacienteId = request.PacienteId,
+            FechaConsulta = request.FechaConsulta,
+            Sintomas = request.Sintomas?.Trim(),
+            Recomendaciones = request.Recomendaciones?.Trim(),
+            Diagnostico = request.Diagnostico?.Trim()
+        };
+
+        db.Consultas.Add(consulta);
+        await db.SaveChangesAsync();
+
+        var response = new ConsultaResponse(
+            consulta.Id,
+            consulta.MedicoId,
+            consulta.PacienteId,
+            consulta.FechaConsulta,
+            consulta.Sintomas,
+            consulta.Recomendaciones,
+            consulta.Diagnostico);
+
+        return Results.Created($"/api/consultas/{consulta.Id}", response);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al crear la consulta médica. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("CreateConsulta").RequireAuthorization();
+
+app.MapGet("/api/consultas", async (ConsultorioDbContext db) =>
+{
+    try
+    {
+        var consultas = await db.Consultas
+            .AsNoTracking()
+            .Select(c => new ConsultaResponse(
+                c.Id,
+                c.MedicoId,
+                c.PacienteId,
+                c.FechaConsulta,
+                c.Sintomas,
+                c.Recomendaciones,
+                c.Diagnostico))
+            .ToListAsync();
+
+        return Results.Ok(consultas);
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al consultar las consultas médicas. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("GetConsultas").RequireAuthorization();
+
+app.MapDelete("/api/consultas/{id:int}", async (int id, ConsultorioDbContext db) =>
+{
+    try
+    {
+        var consulta = await db.Consultas.FindAsync(id);
+        if (consulta is null)
+        {
+            return Results.NotFound();
+        }
+
+        db.Consultas.Remove(consulta);
+        await db.SaveChangesAsync();
+
+        return Results.NoContent();
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem($"Ocurrió un error al eliminar la consulta médica. {ex.Message}", statusCode: StatusCodes.Status500InternalServerError);
+    }
+}).WithName("DeleteConsulta").RequireAuthorization();
 
 app.Run();

--- a/backend/Services/IJwtTokenService.cs
+++ b/backend/Services/IJwtTokenService.cs
@@ -1,0 +1,9 @@
+using Backend.Models;
+using Backend.Services.Models;
+
+namespace Backend.Services;
+
+public interface IJwtTokenService
+{
+    TokenResult GenerateToken(Usuario usuario);
+}

--- a/backend/Services/IPasswordService.cs
+++ b/backend/Services/IPasswordService.cs
@@ -1,0 +1,7 @@
+namespace Backend.Services;
+
+public interface IPasswordService
+{
+    string HashPassword(string password);
+    bool VerifyPassword(string hashedPassword, string providedPassword);
+}

--- a/backend/Services/JwtTokenService.cs
+++ b/backend/Services/JwtTokenService.cs
@@ -1,0 +1,48 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Backend.Models;
+using Backend.Options;
+using Backend.Services.Models;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Backend.Services;
+
+public sealed class JwtTokenService(IOptions<JwtSettings> options) : IJwtTokenService
+{
+    private readonly JwtSettings _settings = options.Value;
+
+    public TokenResult GenerateToken(Usuario usuario)
+    {
+        ArgumentNullException.ThrowIfNull(usuario);
+
+        var expiration = DateTime.UtcNow.AddMinutes(_settings.ExpiresMinutes);
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_settings.Key));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, usuario.Id.ToString()),
+            new(JwtRegisteredClaimNames.Email, usuario.Correo),
+            new("name", usuario.NombreCompleto)
+        };
+
+        if (usuario.MedicoId.HasValue)
+        {
+            claims.Add(new Claim("medicoId", usuario.MedicoId.Value.ToString()));
+        }
+
+        var token = new JwtSecurityToken(
+            issuer: _settings.Issuer,
+            audience: _settings.Audience,
+            claims: claims,
+            expires: expiration,
+            signingCredentials: credentials);
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.WriteToken(token);
+
+        return new TokenResult(jwt, expiration);
+    }
+}

--- a/backend/Services/Models/TokenResult.cs
+++ b/backend/Services/Models/TokenResult.cs
@@ -1,0 +1,3 @@
+namespace Backend.Services.Models;
+
+public sealed record TokenResult(string Token, DateTime Expiration);

--- a/backend/Services/PasswordService.cs
+++ b/backend/Services/PasswordService.cs
@@ -1,0 +1,49 @@
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Cryptography.KeyDerivation;
+
+namespace Backend.Services;
+
+public sealed class PasswordService : IPasswordService
+{
+    private const int SaltSize = 16; // 128 bit
+    private const int KeySize = 32;  // 256 bit
+    private const int Iterations = 100_000;
+
+    public string HashPassword(string password)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(password);
+
+        var salt = RandomNumberGenerator.GetBytes(SaltSize);
+        var hash = KeyDerivation.Pbkdf2(password, salt, KeyDerivationPrf.HMACSHA256, Iterations, KeySize);
+
+        return $"{Convert.ToBase64String(salt)}.{Convert.ToBase64String(hash)}";
+    }
+
+    public bool VerifyPassword(string hashedPassword, string providedPassword)
+    {
+        if (string.IsNullOrWhiteSpace(hashedPassword) || string.IsNullOrEmpty(providedPassword))
+        {
+            return false;
+        }
+
+        var parts = hashedPassword.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 2)
+        {
+            return false;
+        }
+
+        try
+        {
+            var salt = Convert.FromBase64String(parts[0]);
+            var storedHashBytes = Convert.FromBase64String(parts[1]);
+
+            var computedHash = KeyDerivation.Pbkdf2(providedPassword, salt, KeyDerivationPrf.HMACSHA256, Iterations, KeySize);
+
+            return CryptographicOperations.FixedTimeEquals(storedHashBytes, computedHash);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+}

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -7,6 +7,12 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "Consultorio": "Server=localhost;User Id=sa;Password=triplea;Database=bdmedica;TreatTinyAsBoolean=true;Encrypt=False;TrustServerCertificate=True;"
+    "Consultorio": "Server=localhost;User Id=sa;Password=triplea;Database=bdmedica;Encrypt=False;TrustServerCertificate=True;"
+  },
+  "Jwt": {
+    "Key": "SuperSecretKeyForJwtGenerationChangeThis",
+    "Issuer": "ConsultorioApi",
+    "Audience": "ConsultorioApiClients",
+    "ExpiresMinutes": 60
   }
 }

--- a/scripts/create_users_db.sql
+++ b/scripts/create_users_db.sql
@@ -1,34 +1,83 @@
-GO
-IF DB_ID(N'bdmedica') IS NULL
-BEGIN
-    CREATE DATABASE bdmedica;
-END;
+USE [bdmedica];
 GO
 
-USE bdmedica;
+IF OBJECT_ID('dbo.consultas', 'U') IS NOT NULL
+    DROP TABLE dbo.consultas;
 GO
 
-IF OBJECT_ID(N'dbo.Usuarios', N'U') IS NOT NULL
-BEGIN
-    DROP TABLE dbo.Usuarios;
-END;
+IF OBJECT_ID('dbo.usuarios', 'U') IS NOT NULL
+    DROP TABLE dbo.usuarios;
 GO
 
-CREATE TABLE dbo.Usuarios
+IF OBJECT_ID('dbo.pacientes', 'U') IS NOT NULL
+    DROP TABLE dbo.pacientes;
+GO
+
+IF OBJECT_ID('dbo.medicos', 'U') IS NOT NULL
+    DROP TABLE dbo.medicos;
+GO
+
+CREATE TABLE dbo.medicos
 (
-    idUsuarios INT IDENTITY(1,1) PRIMARY KEY,
-    usuario NVARCHAR(50) NOT NULL,
-    nombre NVARCHAR(100) NOT NULL,
-    contrasena NVARCHAR(100) NOT NULL,
-    activo BIT NOT NULL
+    id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+    primer_nombre NVARCHAR(100) NOT NULL,
+    segundo_nombre NVARCHAR(100) NULL,
+    apellido_paterno NVARCHAR(100) NOT NULL,
+    apellido_materno NVARCHAR(100) NULL,
+    cedula NVARCHAR(50) NOT NULL,
+    telefono NVARCHAR(20) NULL,
+    especialidad NVARCHAR(150) NULL,
+    email NVARCHAR(150) NULL,
+    activo BIT NOT NULL DEFAULT (1),
+    fecha_creacion DATETIME2 NOT NULL DEFAULT (SYSUTCDATETIME())
 );
 GO
 
-SET IDENTITY_INSERT dbo.Usuarios ON;
-INSERT INTO dbo.Usuarios (idUsuarios, usuario, nombre, contrasena, activo)
-VALUES
-    (1, N'recepcion', N'Laura Sánchez', N'recepcion123', 1),
-    (2, N'doctor1', N'Dr. Jorge Medina', N'consulta2024', 1),
-    (3, N'admin', N'Administración', N'admin2024', 0);
-SET IDENTITY_INSERT dbo.Usuarios OFF;
+CREATE UNIQUE INDEX IX_medicos_cedula ON dbo.medicos (cedula);
+GO
+
+CREATE UNIQUE INDEX IX_medicos_email ON dbo.medicos (email) WHERE email IS NOT NULL;
+GO
+
+CREATE TABLE dbo.pacientes
+(
+    id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+    primer_nombre NVARCHAR(100) NOT NULL,
+    segundo_nombre NVARCHAR(100) NULL,
+    apellido_paterno NVARCHAR(100) NOT NULL,
+    apellido_materno NVARCHAR(100) NULL,
+    telefono NVARCHAR(20) NULL,
+    activo BIT NOT NULL DEFAULT (1),
+    fecha_creacion DATETIME2 NOT NULL DEFAULT (SYSUTCDATETIME())
+);
+GO
+
+CREATE TABLE dbo.usuarios
+(
+    id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+    correo NVARCHAR(150) NOT NULL,
+    password NVARCHAR(512) NOT NULL,
+    nombre_completo NVARCHAR(200) NOT NULL,
+    id_medico INT NULL,
+    activo BIT NOT NULL DEFAULT (1),
+    fecha_creacion DATETIME2 NOT NULL DEFAULT (SYSUTCDATETIME()),
+    CONSTRAINT FK_usuarios_medicos FOREIGN KEY (id_medico) REFERENCES dbo.medicos(id) ON DELETE SET NULL
+);
+GO
+
+CREATE UNIQUE INDEX IX_usuarios_correo ON dbo.usuarios (correo);
+GO
+
+CREATE TABLE dbo.consultas
+(
+    id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+    id_medico INT NOT NULL,
+    id_paciente INT NOT NULL,
+    fecha_consulta DATETIME2 NOT NULL,
+    sintomas NVARCHAR(500) NULL,
+    recomendaciones NVARCHAR(500) NULL,
+    diagnostico NVARCHAR(500) NULL,
+    CONSTRAINT FK_consultas_medicos FOREIGN KEY (id_medico) REFERENCES dbo.medicos(id) ON DELETE NO ACTION,
+    CONSTRAINT FK_consultas_pacientes FOREIGN KEY (id_paciente) REFERENCES dbo.pacientes(id) ON DELETE NO ACTION
+);
 GO


### PR DESCRIPTION
## Summary
- rebuild the ASP.NET Core 8 minimal API with JWT authentication and Swagger security metadata
- add Entity Framework entities and DbContext mappings for médicos, pacientes, usuarios y consultas with SQL Server configuration
- implement CRUD endpoints with error handling and supporting DTOs plus PBKDF2 password hashing utilities and SQL setup script

## Testing
- `dotnet build backend/BackendApi.sln` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0304cd810832cb3c846ccb16846c2