### PR TITLE
Fix CORS policy configuration in Program.cs

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -51,11 +51,7 @@ builder.Services.AddAuthentication(options =>
 
 builder.Services.AddAuthorization();
 
-builder.Services.AddAuthentication(options =>
-{
-    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-}).AddJwtBearer(options =>
+builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowAll", policy =>
     {


### PR DESCRIPTION
## Summary
- configure the AllowAll CORS policy with AddCors instead of JwtBearer options so the API build succeeds

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0352434b0832caddd2c8091d2bb31