### PR TITLE
Actualizar autenticación del frontend a la nueva API

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -2,24 +2,39 @@ import { defineStore } from 'pinia';
 
 type AuthUser = {
   id: number;
-  usuario: string;
-  nombre: string;
+  correo: string;
+  nombreCompleto: string;
+  medicoId: number | null;
+};
+
+type AuthSession = {
+  token: string;
+  expiracion: string;
+  usuario: AuthUser;
 };
 
 interface AuthState {
   user: AuthUser | null;
+  token: string | null;
+  expiracion: string | null;
 }
 
 export const useAuthStore = defineStore('auth', {
   state: (): AuthState => ({
-    user: null
+    user: null,
+    token: null,
+    expiracion: null
   }),
   actions: {
-    setUser(user: AuthUser) {
-      this.user = user;
+    setSession(session: AuthSession) {
+      this.user = session.usuario;
+      this.token = session.token;
+      this.expiracion = session.expiracion;
     },
     logout() {
       this.user = null;
+      this.token = null;
+      this.expiracion = null;
     }
   }
 });

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -6,8 +6,8 @@ import { useAuthStore } from '@/stores/auth';
 const authStore = useAuthStore();
 const router = useRouter();
 
-const nombre = computed(() => authStore.user?.nombre ?? '');
-const usuario = computed(() => authStore.user?.usuario ?? '');
+const nombre = computed(() => authStore.user?.nombreCompleto ?? '');
+const correo = computed(() => authStore.user?.correo ?? '');
 
 const logout = () => {
   authStore.logout();
@@ -63,7 +63,7 @@ const menuSections = [
           <div class="flex flex-col items-start gap-3 text-sm text-emerald-100 md:items-end">
             <div class="rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-5 py-3">
               Sesión iniciada como <span class="font-semibold text-white">{{ nombre }}</span>
-              <span class="ml-1 text-emerald-300">({{ usuario }})</span>
+              <span class="ml-1 text-emerald-300">({{ correo }})</span>
             </div>
             <button
               class="inline-flex items-center justify-center rounded-xl border border-emerald-400/60 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-200 transition hover:bg-emerald-500/10"

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -6,9 +6,20 @@ import { useAuthStore } from '@/stores/auth';
 const router = useRouter();
 const authStore = useAuthStore();
 
+type LoginResponse = {
+  token: string;
+  expiracion: string;
+  usuario: {
+    id: number;
+    correo: string;
+    nombreCompleto: string;
+    medicoId: number | null;
+  };
+};
+
 const credentials = reactive({
-  usuario: '',
-  contrasena: ''
+  correo: '',
+  password: ''
 });
 
 const loading = ref(false);
@@ -16,7 +27,7 @@ const errorMessage = ref('');
 const showErrorModal = ref(false);
 
 const apiBase = import.meta.env.VITE_API_BASE ?? 'https://localhost:59831';
-const invalidCredentialsMessage = 'usuario o contraseña no válidos';
+const invalidCredentialsMessage = 'Correo o contraseña no válidos';
 
 const handleSubmit = async () => {
   errorMessage.value = '';
@@ -50,8 +61,8 @@ const handleSubmit = async () => {
       throw new Error(apiErrorMessage);
     }
 
-    const data = await response.json();
-    authStore.setUser(data);
+    const data = (await response.json()) as LoginResponse;
+    authStore.setSession(data);
     router.push({ name: 'dashboard' });
   } catch (error) {
     if (error instanceof Error && error.message.trim().length > 0) {
@@ -106,13 +117,13 @@ const closeErrorModal = () => {
 
           <form class="space-y-5" @submit.prevent="handleSubmit">
             <div class="space-y-2">
-              <label class="block text-sm font-medium text-slate-300" for="usuario">Usuario</label>
+              <label class="block text-sm font-medium text-slate-300" for="correo">Correo electrónico</label>
               <input
-                id="usuario"
-                v-model.trim="credentials.usuario"
+                id="correo"
+                v-model.trim="credentials.correo"
                 autocomplete="username"
                 class="w-full rounded-xl border border-slate-700 bg-slate-900 px-4 py-3 text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
-                placeholder="Ej. recepcion"
+                placeholder="correo@ejemplo.com"
                 required
                 type="text"
               />
@@ -122,7 +133,7 @@ const closeErrorModal = () => {
               <label class="block text-sm font-medium text-slate-300" for="contrasena">Contraseña</label>
               <input
                 id="contrasena"
-                v-model.trim="credentials.contrasena"
+                v-model.trim="credentials.password"
                 autocomplete="current-password"
                 class="w-full rounded-xl border border-slate-700 bg-slate-900 px-4 py-3 text-slate-100 shadow-inner focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
                 placeholder="Introduce tu contraseña"


### PR DESCRIPTION
## Summary
- ajustar el formulario de inicio de sesión para enviar `correo` y `password` y consumir la nueva respuesta del endpoint `/auth/login`
- actualizar el store de autenticación para guardar token, expiración y los campos del usuario devueltos por la API
- mostrar la información de sesión usando el correo y el nombre completo del usuario autenticado

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e036069de0832cac2101e36e25c123