### PR TITLE
Seed admin user via database script

### DIFF
--- a/scripts/create_users_db.sql
+++ b/scripts/create_users_db.sql
@@ -81,3 +81,15 @@ CREATE TABLE dbo.consultas
     CONSTRAINT FK_consultas_pacientes FOREIGN KEY (id_paciente) REFERENCES dbo.pacientes(id) ON DELETE NO ACTION
 );
 GO
+
+INSERT INTO dbo.usuarios (correo, password, nombre_completo, id_medico, activo, fecha_creacion)
+VALUES
+(
+    'admin@consultorio.com',
+    'MXFQlDjUe8V65YdAjFvMXA==.nlT+YStkL0LCH+Deu08PvWUGZmadvThJr1pD7iCnupY=',
+    'Administrador del sistema',
+    NULL,
+    1,
+    SYSUTCDATETIME()
+);
+GO


### PR DESCRIPTION
## Summary
- remove the runtime admin user seeding from `Program.cs`
- add an insert statement to `scripts/create_users_db.sql` to create the admin user with password 123

## Testing
- not run (dotnet CLI not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e038aa623c832c8f6c1d42f3e71298