### PR TITLE
Update branding to Clínica Mágica with medical background

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,7 +4,12 @@
 
 <style scoped>
 :global(body) {
-  background: #020617;
+  background-color: #020617;
+  background-image: linear-gradient(rgba(2, 6, 23, 0.8), rgba(2, 6, 23, 0.9)),
+    url('https://images.unsplash.com/photo-1580281658629-54d6c9044070?auto=format&fit=crop&w=1920&q=80');
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
   color: #e2e8f0;
   font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   min-height: 100vh;

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -54,7 +54,7 @@ const menuSections = [
       <header class="flex flex-col gap-6 rounded-3xl border border-emerald-500/20 bg-slate-950/80 p-8 shadow-2xl shadow-emerald-500/10 backdrop-blur">
         <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
-            <p class="text-sm uppercase tracking-[0.3em] text-emerald-300">Consultorio Integral</p>
+            <p class="text-sm uppercase tracking-[0.3em] text-emerald-300">Clínica Mágica</p>
             <h1 class="text-3xl font-bold text-white md:text-4xl">Menú principal</h1>
             <p class="mt-3 max-w-2xl text-sm text-slate-300">
               Selecciona un módulo para comenzar a trabajar. Desde aquí podrás registrar nuevas consultas, revisar historiales y administrar el equipo del consultorio.

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -82,12 +82,16 @@ const closeErrorModal = () => {
 </script>
 
 <template>
-  <main class="flex min-h-screen items-center justify-center px-4 py-8">
+  <main class="flex min-h-screen flex-col items-center justify-start gap-10 px-4 py-12">
+    <header class="w-full max-w-4xl text-center">
+      <h1 class="text-5xl font-black uppercase tracking-[0.4em] text-emerald-200 drop-shadow-lg sm:text-6xl">Clínica Mágica</h1>
+    </header>
+
     <div class="w-full max-w-4xl overflow-hidden rounded-3xl border border-slate-800 bg-slate-900/70 shadow-2xl shadow-emerald-500/10">
       <div class="grid gap-8 md:grid-cols-2">
         <section class="flex flex-col justify-between gap-6 bg-gradient-to-br from-emerald-500/10 via-emerald-500/5 to-slate-900 p-8">
           <div>
-            <p class="text-sm uppercase tracking-[0.3em] text-emerald-300">Consultorio Integral</p>
+            <p class="text-sm uppercase tracking-[0.3em] text-emerald-300">Clínica Mágica</p>
             <h1 class="mt-3 text-3xl font-bold text-white md:text-4xl">Acceso al panel clínico</h1>
             <p class="mt-4 text-sm leading-relaxed text-slate-300">
               Administra citas, expedientes y seguimientos desde un único lugar. Ingresa con tu usuario asignado por la administración del consultorio.


### PR DESCRIPTION
## Summary
- replace "Consultorio Integral" branding with "Clínica Mágica" across the login and dashboard views
- add a centered, large Clínica Mágica heading at the top of the login page for clearer branding
- apply a medical-themed background image to the app shell to reinforce the new branding

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e041e835c4832c95fd8911a7471954