### PR TITLE
Add user list modal to user management view

### DIFF
--- a/frontend/src/views/UserCreateView.vue
+++ b/frontend/src/views/UserCreateView.vue
@@ -11,6 +11,15 @@ type CreateUserPayload = {
   activo: boolean;
 };
 
+type UsuarioResponse = {
+  id: number;
+  correo: string;
+  nombreCompleto: string;
+  medicoId: number | null;
+  activo: boolean;
+  fechaCreacion: string;
+};
+
 const router = useRouter();
 const authStore = useAuthStore();
 
@@ -27,6 +36,12 @@ const loading = ref(false);
 const errorMessage = ref('');
 const successMessage = ref('');
 const apiBase = import.meta.env.VITE_API_BASE ?? 'https://localhost:59831';
+
+const showUsersModal = ref(false);
+const usersLoading = ref(false);
+const usersError = ref('');
+const users = ref<UsuarioResponse[]>([]);
+const deletingUserIds = ref<number[]>([]);
 
 const canSubmit = computed(() => {
   return (
@@ -139,6 +154,97 @@ const handleSubmit = async () => {
 const goBack = () => {
   router.push({ name: 'dashboard' });
 };
+
+const buildAuthHeaders = (): HeadersInit => {
+  const headers: Record<string, string> = {};
+
+  if (authStore.token) {
+    headers.Authorization = `Bearer ${authStore.token}`;
+  }
+
+  return headers;
+};
+
+const fetchUsers = async () => {
+  usersError.value = '';
+  usersLoading.value = true;
+
+  try {
+    if (!authStore.token) {
+      throw new Error('Debes iniciar sesión para ver los usuarios.');
+    }
+
+    const response = await fetch(`${apiBase}/api/usuarios`, {
+      method: 'GET',
+      headers: buildAuthHeaders()
+    });
+
+    if (!response.ok) {
+      throw new Error('No se pudieron obtener los usuarios.');
+    }
+
+    const data = (await response.json()) as UsuarioResponse[];
+    users.value = data;
+  } catch (error) {
+    users.value = [];
+    usersError.value =
+      error instanceof Error && error.message.trim().length > 0
+        ? error.message
+        : 'Ocurrió un error al consultar los usuarios.';
+  } finally {
+    usersLoading.value = false;
+  }
+};
+
+const openUsersModal = () => {
+  showUsersModal.value = true;
+  void fetchUsers();
+};
+
+const closeUsersModal = () => {
+  showUsersModal.value = false;
+  usersError.value = '';
+};
+
+const removeDeletingUserId = (id: number) => {
+  deletingUserIds.value = deletingUserIds.value.filter((currentId) => currentId !== id);
+};
+
+const deleteUser = async (id: number) => {
+  const confirmed = window.confirm('¿Deseas eliminar este usuario? Esta acción no se puede deshacer.');
+  if (!confirmed) {
+    return;
+  }
+
+  deletingUserIds.value = [...deletingUserIds.value, id];
+  usersError.value = '';
+
+  try {
+    if (!authStore.token) {
+      throw new Error('Debes iniciar sesión para eliminar usuarios.');
+    }
+
+    const response = await fetch(`${apiBase}/api/usuarios/${id}`, {
+      method: 'DELETE',
+      headers: buildAuthHeaders()
+    });
+
+    if (!response.ok) {
+      throw new Error('No se pudo eliminar el usuario.');
+    }
+
+    await fetchUsers();
+  } catch (error) {
+    usersError.value =
+      error instanceof Error && error.message.trim().length > 0
+        ? error.message
+        : 'Ocurrió un error al eliminar el usuario.';
+  } finally {
+    removeDeletingUserId(id);
+  }
+};
+
+const isDeletingUser = (id: number) => deletingUserIds.value.includes(id);
 </script>
 
 <template>
@@ -148,7 +254,7 @@ const goBack = () => {
         <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
             <p class="text-sm uppercase tracking-[0.3em] text-emerald-300">Administración</p>
-            <h1 class="text-3xl font-bold text-white md:text-4xl">Alta de usuarios</h1>
+            <h1 class="text-3xl font-bold text-white md:text-4xl">Usuarios</h1>
             <p class="mt-3 max-w-2xl text-sm text-slate-300">
               Completa el formulario para registrar nuevos usuarios en el sistema. Los datos se guardarán automáticamente en la base de datos.
             </p>
@@ -160,6 +266,13 @@ const goBack = () => {
               @click="goBack"
             >
               Volver al panel
+            </button>
+            <button
+              class="inline-flex items-center justify-center rounded-xl border border-emerald-400/60 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-200 transition hover:bg-emerald-500/10"
+              type="button"
+              @click="openUsersModal"
+            >
+              Ver usuarios
             </button>
           </div>
         </div>
@@ -262,5 +375,85 @@ const goBack = () => {
         </form>
       </section>
     </div>
+    <transition name="fade">
+      <div
+        v-if="showUsersModal"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-10 backdrop-blur"
+      >
+        <div class="relative w-full max-w-3xl overflow-hidden rounded-3xl border border-emerald-500/30 bg-slate-950 shadow-2xl">
+          <header class="flex items-center justify-between border-b border-emerald-500/20 bg-slate-900/60 px-6 py-4">
+            <div>
+              <p class="text-xs uppercase tracking-[0.3em] text-emerald-300">Usuarios</p>
+              <h2 class="text-xl font-semibold text-white">Listado de usuarios</h2>
+            </div>
+            <button
+              class="rounded-lg border border-emerald-400/60 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-200 transition hover:bg-emerald-500/10"
+              type="button"
+              @click="closeUsersModal"
+            >
+              Cerrar
+            </button>
+          </header>
+          <section class="max-h-[70vh] overflow-y-auto px-6 py-5 text-sm text-slate-200">
+            <div v-if="usersLoading" class="py-10 text-center text-emerald-200">Cargando usuarios...</div>
+            <div v-else>
+              <div v-if="usersError" class="mb-4 rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-rose-100">
+                {{ usersError }}
+              </div>
+              <div v-else-if="users.length === 0" class="py-10 text-center text-slate-400">No hay usuarios registrados.</div>
+              <table v-else class="min-w-full divide-y divide-slate-800">
+                <thead class="bg-slate-900/70 text-left text-xs uppercase tracking-wider text-slate-400">
+                  <tr>
+                    <th class="px-4 py-3">Nombre</th>
+                    <th class="px-4 py-3">Correo</th>
+                    <th class="px-4 py-3">Activo</th>
+                    <th class="px-4 py-3 text-right">Acciones</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-800 text-sm text-slate-200">
+                  <tr v-for="usuario in users" :key="usuario.id">
+                    <td class="px-4 py-3 font-medium text-white">{{ usuario.nombreCompleto }}</td>
+                    <td class="px-4 py-3">{{ usuario.correo }}</td>
+                    <td class="px-4 py-3">
+                      <span
+                        :class="[
+                          'rounded-full px-3 py-1 text-xs font-semibold',
+                          usuario.activo ? 'bg-emerald-500/20 text-emerald-300' : 'bg-rose-500/20 text-rose-200'
+                        ]"
+                      >
+                        {{ usuario.activo ? 'Activo' : 'Inactivo' }}
+                      </span>
+                    </td>
+                    <td class="px-4 py-3 text-right">
+                      <button
+                        class="inline-flex items-center justify-center rounded-lg border border-rose-400/60 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-rose-200 transition hover:bg-rose-500/10 disabled:cursor-not-allowed disabled:opacity-60"
+                        :disabled="isDeletingUser(usuario.id)"
+                        type="button"
+                        @click="deleteUser(usuario.id)"
+                      >
+                        <span v-if="!isDeletingUser(usuario.id)">Eliminar</span>
+                        <span v-else>Eliminando...</span>
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+      </div>
+    </transition>
   </main>
 </template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- rename the user creation header to "Usuarios" and add a secondary "Ver usuarios" action button
- implement a modal that fetches and lists users with loading and error handling
- allow deleting users from the modal with automatic refresh and animated overlay styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e04d9ec1e4832c8afaff969c31578c