### PR TITLE
Enable editing of usuarios from the admin interface

### DIFF
--- a/backend/Contracts/UsuarioDtos.cs
+++ b/backend/Contracts/UsuarioDtos.cs
@@ -2,4 +2,6 @@ namespace Backend.Contracts;
 
 public sealed record CreateUsuarioRequest(string Correo, string Password, string NombreCompleto, int? MedicoId, bool Activo);
 
+public sealed record UpdateUsuarioRequest(string Correo, string NombreCompleto, int? MedicoId, bool Activo);
+
 public sealed record UsuarioResponse(int Id, string Correo, string NombreCompleto, int? MedicoId, bool Activo, DateTime FechaCreacion);


### PR DESCRIPTION
## Summary
- add an update DTO and endpoint so usuarios can be modified via the API
- extend the usuarios management view with an edit modal and update workflow

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68e05521378c832ca779562ba2036cdd